### PR TITLE
Hide several irrelevant french words from the wordcloud

### DIFF
--- a/tooling/wordcloudgenerator/app.js
+++ b/tooling/wordcloudgenerator/app.js
@@ -41,7 +41,7 @@ function fill(n) {
 function getWords(words) {
     var keys = Object.keys(words);
     var res = [];
-    var common = ['le', 'la', 'les', 'dans', 'des', 'present', 'de', 'du', 'en', 'à', 'qui', 'sont', 'cet', 'cette', 'notre', 'un', 'une', 'est', 'ces', 'd\'un', 'avec', 'et', 'pour', 'par', 'los', 'sistemas', 'para', 'ce', 'sur', 'modelos', 'nous', 'je', 'tu', 'il', 'elle', 'ils', 'elles', 'vous', 'el', 'se']
+    var common = ['le', 'la', 'les', 'dans', 'des', 'present', 'de', 'du', 'en', 'à', 'qui', 'sont', 'cet', 'cette', 'notre', 'un', 'une', 'est', 'ces', 'd\'un', 'avec', 'et', 'pour', 'par', 'los', 'sistemas', 'para', 'ce', 'sur', 'modelos', 'nous', 'je', 'tu', 'il', 'elle', 'ils', 'elles', 'vous', 'el', 'se', 'au', 'aux', 'afin', 'leur', 'partir', 'comme', 'peuvent', 'deux', 'pas', 'ainsi', 'proposons', 'être', 'son']
     keys.forEach(key => {
         if (!common.includes(key)) {
             res.push({


### PR DESCRIPTION
Those words appear because they are automatically gathered from HAL but since they are irrelevant they should be filtered out.