### PR TITLE
enable buildFuture: allow the website to include upcoming events

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -9,6 +9,8 @@ verbose: true
 verbseLog: true
 useResourceCacheWhen: never
 
+buildFuture: true
+
 params:
   twitter: DiverSE_inria
   github: diverse-project

--- a/content/talks/20240711-diverse-coffee.md
+++ b/content/talks/20240711-diverse-coffee.md
@@ -1,5 +1,5 @@
 ---
-date: 2024-07-111T13:00:00
+date: 2024-07-11T13:00:00
 title: Internships
 abstract: >
   


### PR DESCRIPTION
The website does not include events of which the date is after the current date,
e.g., a DiverSE Coffee talk will appear on the website only if the commit is
pushed a day after the coffee date.

Enabling this option would allow us to share the abstract before or during the
coffee and not context-switch and forget to do it the day after.